### PR TITLE
Add feature to split input between multiple plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,19 @@ $ hmu <plugin> [...arguments], [...]
 ```
 Example:
 ```
+$ hmu npm osia
+```
+
+Separate multiple plugins with `,` (comma) using [`cli-list`](https://github.com/jamen/cli-list):
+```
 $ hmu npm osia, gh osiajs
 ```
-Separate multiple plugins with `,` (comma) using [`cli-list`](https://github.com/jamen/cli-list).
+
+Split input between multiple plugins with `~` (tilde):
+```
+$ hmu npm~gh osia
+# Equivalent to: npm osia, gh osia
+```
 
 ## Credits
 | ![jamen][avatar] |

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,8 +1,11 @@
 #!/usr/bin/env node
+'use strict';
+
 const hmu = require('.');
 const minimist = require('minimist');
 const list = require('cli-list');
 const path = require('path');
+const sate = require('sate');
 
 // Create CLI
 const args = process.argv.slice(2);
@@ -10,12 +13,24 @@ const opts = { boolean: false };
 const cli = list(args).map(set => minimist(set, opts));
 const gbl = cli[0];
 
+if (!args.length) {
+  console.error('Usage: hmu <plugin> [...arguments], ...');
+  process.exit(0);
+}
+
+let plugins = cli;
+
 // Convert to `hmu` input
-const plugins = cli.map(set => ({ name: set._[0], args: set._.slice(1), opts: set }));
+plugins = plugins.map(set => ({ name: set._[0], args: set._.slice(1), opts: set }));
+
+// Convert joined plugins into separate ones
+plugins = sate(plugins, function* expand(plugin) {
+  const names = plugin.name.split('~');
+  yield* names.map(name => Object.assign({}, plugin, { name }));
+});
 
 // Run
-hmu(plugins, gbl.dirs && gbl.dirs.split(path.delimeter)).then(() => {
-  console.log('\n');
-}, err => {
+hmu(plugins, gbl.dirs && gbl.dirs.split(path.delimeter))
+.catch(err => {
   console.error(gbl.verbose ? err.stack : err.message);
 });

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,13 +1,18 @@
 const each = require('async-each');
 const resolve = require('./resolve');
+const Circuit = require('promise-circuit');
 
 module.exports = function hmu(plugins, dirs) {
-  return new Promise((finish, reject) => {
-    each(plugins, plugin => {
-      resolve(plugin.name, dirs).then(
-        entry => require(entry)(plugin.args, plugin.opts),
-        err => reject(err)
-      ).catch(err => console.error(err.stack));
-    }, finish);
+  return new Promise(finish => {
+    const proc = new Circuit();
+
+    each(plugins, (plugin, next) => {
+      resolve(plugin.name, dirs).then(entry => {
+        proc.add(require(entry), [plugin.args, plugin.opts]);
+        next();
+      });
+    }, () => {
+      proc.run().then(finish);
+    });
   });
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
     "async-each": "^1.0.0",
     "cli-list": "^0.1.6",
     "minimist": "^1.2.0",
-    "resolve": "^1.1.7"
+    "promise-circuit": "^0.2.0",
+    "resolve": "^1.1.7",
+    "sate": "^1.0.2"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
#Split input between plugins:
```
$ hmu npm~gh osia
```
Equivalent to:
```
$ hmu npm osia, gh osia
```
(Also makes plugins run in series instead of concurrently)

Fixes #1 and #2 